### PR TITLE
interactive documentation with codox klipse theme

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,11 +8,12 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.293"]
                  [org.jsoup/jsoup "1.9.2"]
+                 [viebel/codox-klipse-theme "0.0.1"]
                  [quoin "0.1.2" :exclusions [org.clojure/clojure]]]
 
   :hooks [leiningen.cljsbuild]
 
-  :plugins [[codox "0.6.4"]]
+  :plugins [[lein-codox "0.10.0"]]
   :doo {:build "test"}
 
   :source-paths ["src/clj" "src/cljc" "src/cljs"]
@@ -35,8 +36,16 @@
           }}
 
   :codox {:sources                   ["src" "target/generated-src"]
-          :output-dir                "codox-out"
+          :output-path                "codox-out"
           :src-dir-uri               "http://github.com/davidsantiago/hickory/blob/master"
+          :metadata {:doc/format :markdown}
+          :language :clojurescript
+          :themes [:default [:klipse {:klipse/external-libs  "https://raw.githubusercontent.com/davidsantiago/hickory/master/src/cljc,https://raw.githubusercontent.com/davidsantiago/hickory/master/src/cljs"
+                                      :klipse/require-statement "(ns my.html
+                                                                  (:require [hickory.core :refer [parse as-hiccup as-hickory]]
+                                                                            [hickory.render :refer [hickory-to-html hiccup-to-html]]
+                                                                            [hickory.convert :refer [hiccup-to-hickory]]))
+                                                                "}]]
           :src-linenum-anchor-prefix "L"}
 
   )

--- a/src/cljc/hickory/render.cljc
+++ b/src/cljc/hickory/render.cljc
@@ -119,6 +119,10 @@
    fast or heavy-duty, and definitely not a replacement for dedicated hiccup
    renderers, like hiccup itself, which *is* fast and heavy-duty.
 
+```klipse
+  (hiccup-to-html '([:html {} [:head {}] [:body {} [:a {} \"foo\"]]]))
+```
+
    Note that it will NOT in general be the case that
 
      (= my-html-src (hiccup-to-html (as-hiccup (parse my-html-src))))
@@ -126,7 +130,13 @@
    as we do not keep any letter case or whitespace information, any
    \"tag-soupy\" elements, attribute quote characters used, etc. It will also
    not generally be the case that this function's output will exactly match
-   hiccup's."
+   hiccup's.
+   For instance:
+
+```klipse
+(hiccup-to-html (as-hiccup (parse \"<A href=\\\"foo\\\">foo</A>\")))
+```
+  "
   [hiccup-forms]
   (apply str (map #(render-hiccup-form (hu/normalize-form %)) hiccup-forms)))
 

--- a/src/cljs/hickory/core.cljs
+++ b/src/cljs/hickory/core.cljs
@@ -148,7 +148,20 @@
 
 (defn parse
   "Parse an entire HTML document into a DOM structure that can be
-   used as input to as-hiccup or as-hickory."
+   used as input to as-hiccup or as-hickory.
+
+```klipse
+  (-> (parse \"<a style=\\\"visibility:hidden\\\">foo</a><div style=\\\"color:green\\\"><p>Hello</p></div>\")
+    as-hiccup)
+```
+
+```klipse
+  (-> (parse \"<a style=\\\"visibility:hidden\\\">foo</a><div style=\\\"color:green\\\"><p>Hello</p></div>\")
+    as-hickory)
+```
+
+
+  "
   [s]
   (or (parse-dom-with-domparser s) (parse-dom-with-write s)))
 


### PR DESCRIPTION
@ricardojmendez @davidsantiago  take a look!
Interactive documentation with [codox klipse theme](https://github.com/viebel/codox-klipse-theme).
Here is a live demo of the result:

- http://viebel.github.io/klipse/interactive-doc/hickory/hickory.core.html#var-parse
- http://viebel.github.io/klipse/interactive-doc/hickory/hickory.render.html

I have not yet added interactive examples to all the hickory function as I am not proficient enough with this wonderful lib.

