### PR TITLE
Add up-pred and down-pred fns

### DIFF
--- a/src/cljc/hickory/select.cljc
+++ b/src/cljc/hickory/select.cljc
@@ -79,8 +79,8 @@
    true when the function in the pred argument is called on them, or reaches
    the end."
   [hzip-loc pred]
-  (until zip/up hzip-loc #(clojure.core/or (nil? %)
-                                           (pred %))))
+  (until zip/down hzip-loc #(clojure.core/or (nil? %)
+                                             (pred %))))
 
 (defn next-of-node-type
   "Like clojure.zip/next, but only counts moves to nodes that have

--- a/src/cljc/hickory/select.cljc
+++ b/src/cljc/hickory/select.cljc
@@ -66,6 +66,22 @@
   (until zip/right hzip-loc #(clojure.core/or (nil? %)
                                               (pred %))))
 
+(defn up-pred
+  "Like clojure.zip/up, but moves until it reaches a node that returns
+   true when the function in the pred argument is called on them, or reaches
+   the beginning."
+  [hzip-loc pred]
+  (until zip/up hzip-loc #(clojure.core/or (nil? %)
+                                           (pred %))))
+
+(defn down-pred
+  "Like clojure.zip/down, but moves until it reaches a node that returns
+   true when the function in the pred argument is called on them, or reaches
+   the end."
+  [hzip-loc pred]
+  (until zip/up hzip-loc #(clojure.core/or (nil? %)
+                                           (pred %))))
+
 (defn next-of-node-type
   "Like clojure.zip/next, but only counts moves to nodes that have
    the given type."

--- a/src/cljc/hickory/select.cljc
+++ b/src/cljc/hickory/select.cljc
@@ -74,14 +74,6 @@
   (until zip/up hzip-loc #(clojure.core/or (nil? %)
                                            (pred %))))
 
-(defn down-pred
-  "Like clojure.zip/down, but moves until it reaches a node that returns
-   true when the function in the pred argument is called on them, or reaches
-   the end."
-  [hzip-loc pred]
-  (until zip/down hzip-loc #(clojure.core/or (nil? %)
-                                             (pred %))))
-
 (defn next-of-node-type
   "Like clojure.zip/next, but only counts moves to nodes that have
    the given type."


### PR DESCRIPTION
This PR adds two new functions to traverse a zipper up and down, similar in spirit to next-pred, prev-prev, left-pred, and right-pred. 