### PR TITLE
Refactor recursive parser to an iterative one

### DIFF
--- a/src/clj/hickory/core.clj
+++ b/src/clj/hickory/core.clj
@@ -1,10 +1,17 @@
 (ns hickory.core
   (:require [hickory.utils :as utils]
+            [hickory.zip :as hzip]
             [clojure.zip :as zip])
   (:import [org.jsoup Jsoup]
            [org.jsoup.nodes Attribute Attributes Comment DataNode Document
             DocumentType Element Node TextNode XmlDeclaration]
            [org.jsoup.parser Tag Parser]))
+
+(defn- end-or-recur [as-fn loc data & [skip-child?]]
+  (let [new-loc (-> loc (zip/replace data) zip/next (cond-> skip-child? zip/next))]
+    (if (zip/end? new-loc)
+      (zip/root new-loc)
+      #(as-fn (zip/node new-loc) new-loc))))
 
 ;;
 ;; Protocols
@@ -13,7 +20,7 @@
 (defprotocol HiccupRepresentable
   "Objects that can be represented as Hiccup nodes implement this protocol in
    order to make the conversion."
-  (as-hiccup [this]
+  (as-hiccup [this] [this zip-loc]
     "Converts the node given into a hiccup-format data structure. The
      node must have an implementation of the HiccupRepresentable
      protocol; nodes created by parse or parse-fragment already do."))
@@ -30,7 +37,7 @@
      :attrs    - node's attributes as a map, check :type to see if applicable
      :content  - node's child nodes, in a vector, check :type to see if
                  applicable"
-  (as-hickory [this]
+  (as-hickory [this] [this zip-loc]
     "Converts the node given into a hickory-format data structure. The
      node must have an implementation of the HickoryRepresentable protocol;
      nodes created by parse or parse-fragment already do."))
@@ -39,74 +46,100 @@
 (extend-protocol HiccupRepresentable
   Attribute
   ;; Note the attribute value is not html-escaped; see comment for Element.
-  (as-hiccup [this] [(utils/lower-case-keyword (.getKey this))
-                     (.getValue this)])
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this _] [(utils/lower-case-keyword (.getKey this)) (.getValue this)]))
   Attributes
-  (as-hiccup [this] (into {} (map as-hiccup this)))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this _] (into {} (map as-hiccup this))))
   Comment
-  (as-hiccup [this] (str "<!--" (.getData this) "-->"))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (str "<!--" (.getData this) "-->"))))
   DataNode
-  (as-hiccup [this] (str this))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (str this))))
   Document
-  (as-hiccup [this] (map as-hiccup (.childNodes this)))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (apply list (.childNodes this)))))
   DocumentType
-  (as-hiccup [this] (utils/render-doctype (.attr this "name")
-                                          (.attr this "publicid")
-                                          (.attr this "systemid")))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (utils/render-doctype (.attr this "name")
+                                                                  (.attr this "publicid")
+                                                                  (.attr this "systemid")))))
   Element
-  (as-hiccup [this]
-    ;; There is an issue with the hiccup format, which is that it
-    ;; can't quite cover all the pieces of HTML, so anything it
-    ;; doesn't cover is thrown into a string containing the raw
-    ;; HTML. This presents a problem because it is then never the case
-    ;; that a string in a hiccup form should be html-escaped (except
-    ;; in an attribute value) when rendering; it should already have
-    ;; any escaping. Since the HTML parser quite properly un-escapes
-    ;; HTML where it should, we have to go back and un-un-escape it
-    ;; wherever text would have been un-escaped. We do this by
-    ;; html-escaping the parsed contents of text nodes, and not
-    ;; html-escaping comments, data-nodes, and the contents of
-    ;; unescapable nodes.
-    (let [tag (utils/lower-case-keyword (.tagName this))]
-      (into [] (concat [tag
-                        (as-hiccup (.attributes this))]
-                       (if (utils/unescapable-content tag)
-                         (map str (.childNodes this))
-                         (map as-hiccup (.childNodes this)))))))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc]
+     ;; There is an issue with the hiccup format, which is that it
+     ;; can't quite cover all the pieces of HTML, so anything it
+     ;; doesn't cover is thrown into a string containing the raw
+     ;; HTML. This presents a problem because it is then never the case
+     ;; that a string in a hiccup form should be html-escaped (except
+     ;; in an attribute value) when rendering; it should already have
+     ;; any escaping. Since the HTML parser quite properly un-escapes
+     ;; HTML where it should, we have to go back and un-un-escape it
+     ;; wherever text would have been un-escaped. We do this by
+     ;; html-escaping the parsed contents of text nodes, and not
+     ;; html-escaping comments, data-nodes, and the contents of
+     ;; unescapable nodes.
+     (let [tag (utils/lower-case-keyword (.tagName this))
+           children (cond->> (.childNodes this) (utils/unescapable-content tag) (map str))
+           data (into [] (concat [tag (trampoline as-hiccup (.attributes this))] children))]
+       (end-or-recur as-hiccup loc data (utils/unescapable-content tag)))))
   TextNode
   ;; See comment for Element re: html escaping.
-  (as-hiccup [this] (utils/html-escape (.getWholeText this)))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (utils/html-escape (.getWholeText this)))))
   XmlDeclaration
-  (as-hiccup [this] (str this)))
+  (as-hiccup
+    ([this] (trampoline as-hiccup this (hzip/hiccup-zip this)))
+    ([this loc] (end-or-recur as-hiccup loc (str this)))))
 
 (extend-protocol HickoryRepresentable
   Attribute
-  (as-hickory [this] [(utils/lower-case-keyword (.getKey this))
-                      (.getValue this)])
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this _] [(utils/lower-case-keyword (.getKey this)) (.getValue this)]))
   Attributes
-  (as-hickory [this] (not-empty (into {} (map as-hickory this))))
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this _] (not-empty (into {} (map as-hickory this)))))
   Comment
-  (as-hickory [this] {:type :comment
-                      :content [(.getData this)]})
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc {:type :comment
+                                              :content [(.getData this)]} true)))
   DataNode
-  (as-hickory [this] (str this))
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc (str this))))
   Document
-  (as-hickory [this] {:type :document
-                      :content (not-empty
-                                (into [] (map as-hickory
-                                              (.childNodes this))))})
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc {:type :document
+                                              :content (or (seq (.childNodes this)) nil)})))
   DocumentType
-  (as-hickory [this] {:type :document-type
-                      :attrs (as-hickory (.attributes this))})
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc {:type :document-type
+                                              :attrs (trampoline as-hickory (.attributes this))})))
   Element
-  (as-hickory [this] {:type :element
-                      :attrs (as-hickory (.attributes this))
-                      :tag (utils/lower-case-keyword (.tagName this))
-                      :content (not-empty
-                                (into [] (map as-hickory
-                                              (.childNodes this))))})
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc {:type :element
+                                              :attrs (trampoline as-hickory (.attributes this))
+                                              :tag (utils/lower-case-keyword (.tagName this))
+                                              :content (or (seq (.childNodes this)) nil)})))
   TextNode
-  (as-hickory [this] (.getWholeText this)))
+  (as-hickory
+    ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
+    ([this loc] (end-or-recur as-hickory loc (.getWholeText this)))))
 
 (defn parse
   "Parse an entire HTML document into a DOM structure that can be

--- a/test/cljc/hickory/test/core.cljc
+++ b/test/cljc/hickory/test/core.cljc
@@ -123,3 +123,19 @@
   (is (= "ABC&\n\nDEF."
          (get-in (as-hickory (parse "<pre>ABC&amp;\n\nDEF.</pre>"))
                  [:content 0 :content 1 :content 0 :content 0]))))
+
+;; Issue #50: Tests that the parser does not throw a StackOverflowError when
+;; parsing a document with deeply nested HTML tags.
+(deftest deeply-nested-tags
+  (let [jsoup (parse (apply str (repeat 2048 "<font>abc")))]
+    (is (= [:font {} "abc"]
+           (get-in (vec (as-hiccup jsoup))
+                   (concat [0 3 2] (repeat 2047 3)))))
+    (is (= {:type :element
+            :attrs nil
+            :tag :font
+            :content ["abc"]}
+           (get-in (as-hickory jsoup)
+                   (apply concat
+                          [:content 0 :content 1 :content 0]
+                          (repeat 2047 [:content 1])))))))


### PR DESCRIPTION
This PR resolves #50 for both hiccup and hickory representations, while also retaining the protocol implementation. I essentially just moved the processing logic from the protocols into private functions that use zippers to iteratively traverse the jsoup doc instead of recursively.

I added a unit test that compares against the most deeply nested element of the parsed data structure.